### PR TITLE
fix(build): generates strict schema in a proper folder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ do
     prefix=https://raw.githubusercontent.com/${REPO}/master/${version}/_definitions.json
 
     openapi2jsonschema -o "${version}-standalone" --kubernetes --stand-alone --strict "${schema}"
-    openapi2jsonschema -o "${version}-standalone" --kubernetes --stand-alone "${schema}"
+    openapi2jsonschema -o "${version}-standalone-strict" --kubernetes --stand-alone "${schema}"
     openapi2jsonschema -o "${version}-local" --kubernetes "${schema}"
     openapi2jsonschema -o "${version}" --kubernetes --prefix "${prefix}" "${schema}"
 done


### PR DESCRIPTION
This script was overwriting `-standalone` schema files with its `strict` version, as output was defined as the same folder.